### PR TITLE
Import the "sample fetcher" mechanism from gui-ie

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The UI consists of a form that contains a textarea input. Use this input to buil
 
 ### Parsing and rendering metadata
 
-In the case where the client app is hosted within an iframe, the parent application may expose the url to one or multiple HTML files, containing metadata related to the source that is being queried. In the case of Coreon, this source is a repository. In the case of multiple repositories that can be accessed, there must be one HTML file for each corresponding repository. These HTML files must be placed under a directory with the name "samples", which, itself is placed within the "html" directory of the client application.
+In the case where the client app is hosted within an iframe, the parent application may expose the url to one or multiple HTML files, containing metadata related to the source that is being queried. In the case of Coreon, this source is a repository. In the case of multiple repositories that can be accessed, there must be one HTML file for each corresponding repository. These HTML files must be placed somewhere that can be downloaded by this JavaScript, which means either within this repository (under a directory with the name "samples", which, itself is placed within the "html" directory) or uploaded to the usual ELG public data repository via the ELG metadata editor.
 
 The client app can fetch and display the repository's name, description and sample queries.
 

--- a/html/assets/application.js
+++ b/html/assets/application.js
@@ -15,6 +15,8 @@ requirejs.config({ //this initiates the configuration
         bootstrap: 'assets/lib/bootstrap',
         "mdc":"https://unpkg.com/material-components-web@5.1.0/dist/material-components-web.min",
         "elg/common": "assets/elg/common",
+        // use sample-fetcher from gui-ie to support samples in S3 storage
+        "elg/sample-fetcher": "/dev/gui-ie/assets/elg/sample-fetcher",
     }
 });
 

--- a/html/assets/css/application.css
+++ b/html/assets/css/application.css
@@ -83,3 +83,11 @@ td.elg-expand-control {
 a.elg-feature-value-url {
     white-space: nowrap;
 }
+
+/* sample helper iframes should be invisible */
+iframe.sample-helper-iframe {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 0;
+}

--- a/html/assets/elg/common.js
+++ b/html/assets/elg/common.js
@@ -1,4 +1,4 @@
-define("elg/common", ["jquery", "mdc"], function ($, mdc) {
+define("elg/common", ["jquery", "mdc", "elg/sample-fetcher"], function ($, mdc, sampleFetcher) {
 
     return (function () {
         function ElgCommon(readyCallback, afterErrorCallback, qResponse, submitProgress) {
@@ -133,22 +133,21 @@ define("elg/common", ["jquery", "mdc"], function ($, mdc) {
                     },
                     complete: function () {
                         if (this_.samplesFile) {
-                            $.ajax({
-                                url: this_.samplesFile,
-                                success: function(data) {
+                            // load the sample helper configuration from gui-ie - this is more robust
+                            // than keeping a local copy of the config as it will automatically adapt
+                            // if the gui-ie config adds more helpers in future, but harder to test
+                            // in a local environment.
+                            sampleFetcher("/dev/gui-ie/config/sample-helpers.json").then(function (fetcher) {
+                                fetcher.fetchSample("text", this_.samplesFile).done(function(data) {
                                     var meta = this_.fetchRepoMeta(data);
                                     this_.renderRepoMeta(meta, qResponse);
-                                },
-                                error: function (jqXHR, textStatus, errorThrown) {
+                                }).fail(function (errors) {
                                     console.log('Failed to fetch repository meta file');
-                                },
-                                complete: function () {
-                                    readyCallback();
-                                }
+                                }).always(readyCallback);
                             });
+                        } else {
+                            readyCallback();
                         }
-
-                        readyCallback();
                     }
                 }));
             } else {


### PR DESCRIPTION
The main ELG [gui-ie](https://gitlab.com/european-language-grid/usfd/gui-ie) trial GUIs have recently introduced a mechanism to load sample data files from certain specific origin servers which do not have proper CORS support (specifically the mostly-S3-compatible storage service used to hold user-uploaded data in the platform).  This PR integrates the same mechanism into this GUI so it can also deal with samples uploaded in the ELG metadata editor as well as those hosted within the container itself.